### PR TITLE
Run CI on ubuntu only as lambdas use AL2

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,13 +20,7 @@ env:
 jobs:
   test:
     name: Test
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout Code


### PR DESCRIPTION
<!-- Provide a brief summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->
Use ubuntu only for CI as Lambda functions run on Amazon Linux so testing on windows or mac is irrelevant

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

#### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation if needed.
- [ ] I have updated the tests if needed.
